### PR TITLE
Supporting '(application/json text/plain multipart/form-data) content types

### DIFF
--- a/spiffy-request-vars.scm
+++ b/spiffy-request-vars.scm
@@ -134,8 +134,10 @@
                                   (or max-content-length content-length)
                                   (request-port (current-request)))))
                        (case (header-value 'content-type headers)
-                         ((application/x-www-form-urlencoded)
-                          (form-urldecode body))
+                         ((application/x-www-form-urlencoded) (form-urldecode body))
+                         ((application/json) `((application/json . ,body)))
+                         ((text/plain `((text/plain . ,body))))
+                         ((multipart/form-data `((multipart/form-data . ,body))))
                          (else #f) ;; not supported
                          ))))))
          (vals (case source


### PR DESCRIPTION
This PR allows us to ask for the whole body in case of content types that are `application/json` or `text/plain`; moreover, we can retrieve them via `($ 'application/json)` provided that `$` has been bound to `(request-vars)`, as usual.